### PR TITLE
Add coverage file to artifacts

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -27,22 +27,6 @@ jobs:
         dotnet sln add ./Core/Runtime/Runtime.csproj
         dotnet restore
         dotnet build --configuration Release --no-restore
-    - name: Cache Coverage Tools
-      id: cacheDotCover
-      uses: actions/cache@v2
-      with:
-        path: |
-          dotCover
-        key: ${{ runner.os }}-DotCover
-    - name: Install Coverage Tools
-      if: steps.cacheDotCover.outputs.cache-hit != 'true'
-      run: |
-        mkdir dotCover
-        cd dotCover
-        wget https://download.jetbrains.com/resharper/ReSharperUltimate.2020.1.4/JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz -o JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
-    - run: |
-        cd dotCover
-        tar xvf JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
     - name: Test
       run: |
         cd ./Core/Tests
@@ -52,8 +36,8 @@ jobs:
         cd ../..
         dotnet sln add ./Core/Tests/Tests.csproj
         dotnet add ./Core/Tests/Tests.csproj reference ./Core/Runtime/Runtime.csproj
+        dotnet tool install JetBrains.dotCover.DotNetCliTool --version 2020.1.4
         dotnet restore
-        dotnet test -r ../../test_results/core/ --logger "trx"  
-        ./dotCover/dotCover.exe dotnet --output=Core_Coverage.xml --reportType=XML -- test
+        dotnet dotcover test --dcReportType=XML
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1.0.12 

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -37,9 +37,9 @@ jobs:
         dotnet sln add ./Core/Tests/Tests.csproj
         dotnet add ./Core/Tests/Tests.csproj reference ./Core/Runtime/Runtime.csproj
         dotnet restore
-        dotnet build --configuration Debug --no-restore
+        dotnet build --configuration Debug --no-restore --output ./TestBuild
     - uses: dodopizza/dotcover-action@v1
       with:
-        dotCoverCommand: cover --ReportType=XML --TargetExecutable="./Core/Tests/bin/Debug/netcoreapp2.1/Tests.dll"
+        dotCoverCommand: cover --ReportType=XML --TargetExecutable="./TestBuild/Tests.dll"
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1.0.12 

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -39,7 +39,8 @@ jobs:
       run: |
         mkdir dotCover
         cd dotCover
-        curl https://download.jetbrains.com/resharper/ReSharperUltimate.2020.1.4/JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz -o ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz && tar xvf ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
+        curl --silent --show-error --fail https://download.jetbrains.com/resharper/ReSharperUltimate.2020.1.4/JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz -o ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
+        tar xvf ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
     - name: Test
       run: |
         cd ./Core/Tests

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -36,6 +36,7 @@ jobs:
         cd ../..
         dotnet sln add ./Core/Tests/Tests.csproj
         dotnet add ./Core/Tests/Tests.csproj reference ./Core/Runtime/Runtime.csproj
+        dotnet new tool-manifest
         dotnet tool install JetBrains.dotCover.DotNetCliTool --version 2020.1.4
         dotnet restore
         dotnet dotcover test --dcReportType=XML

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -39,6 +39,6 @@ jobs:
         dotnet restore
     - uses: dodopizza/dotcover-action@v1
       with:
-        dotCoverCommand: dotnet --ReportType=XML -- test "./Core/Tests/Tests.csproj" --Output="./Coverage/Core_coverage.xml"
+        dotCoverCommand: dotnet --ReportType=XML --Output="./Coverage/Core_coverage.xml" -- test "./Core/Tests/Tests.csproj"
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1.0.12 

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -37,9 +37,8 @@ jobs:
         dotnet sln add ./Core/Tests/Tests.csproj
         dotnet add ./Core/Tests/Tests.csproj reference ./Core/Runtime/Runtime.csproj
         dotnet restore
-        dotnet build --configuration Debug --no-restore --output ./TestBuild
     - uses: dodopizza/dotcover-action@v1
       with:
-        dotCoverCommand: cover --ReportType=XML --TargetExecutable="./TestBuild/Tests.dll" --Output="./Coverage/Core_coverage.xml"
+        dotCoverCommand: dotnet --ReportType=XML -- test "./Core/Tests/Tests.csproj" --Output="./Coverage/Core_coverage.xml"
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1.0.12 

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -11,9 +11,10 @@ jobs:
     name: Build Code
     runs-on: linux-latest
     steps:
-    - name: Setup
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup .Net
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.301
     - name: Build
@@ -26,14 +27,15 @@ jobs:
         dotnet sln add ./Core/Runtime/Runtime.csproj
         dotnet restore
         dotnet build --configuration Release --no-restore
-    - name: Install Coverage Tools
+    - name: Cache Coverage Tools
       id: cacheDotCover
       uses: actions/cache@v2
       with:
         path: |
           dotCover
         key: ${{ runner.os }}-DotCover
-    - if: steps.cacheDotCover.outputs.cache-hit != 'true'
+    - name: Install Coverage Tools
+      if: steps.cacheDotCover.outputs.cache-hit != 'true'
       run: |
         mkdir dotCover
         cd dotCover

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         choco install opencover.portable
         OpenCover.Console.exe -register:user -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:test -filter:"+[Core*]* -[Tests*]*" -output:".\Core_coverage.xml" -oldstyle     
-    - uses: actions/upload-artifact@2
+    - uses: actions/upload-artifact@v2
       with:
         name: Core-Coverage
         path: Core_coverage.xml

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build Code
-    runs-on: linux-latest
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -39,10 +39,10 @@ jobs:
       run: |
         mkdir dotCover
         cd dotCover
-        curl https://download.jetbrains.com/resharper/ReSharperUltimate.2020.1.4/JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz -o ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
+        curl https://download.jetbrains.com/resharper/ReSharperUltimate.2020.1.4/JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz -o JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
     - run: |
         cd dotCover
-        tar xvf ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
+        tar xvf JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
     - name: Test
       run: |
         cd ./Core/Tests

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -36,9 +36,8 @@ jobs:
         cd ../..
         dotnet sln add ./Core/Tests/Tests.csproj
         dotnet add ./Core/Tests/Tests.csproj reference ./Core/Runtime/Runtime.csproj
-        dotnet new tool-manifest
-        dotnet tool install JetBrains.dotCover.DotNetCliTool --version 2020.1.4
-        dotnet restore
-        dotnet dotcover test --dcReportType=XML
+    - uses: dodopizza/dotcover-action@v1
+      with:
+        dotCoverCommand: cover --ReportType=XML
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1.0.12 

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: Develop Branch Workflow
 
 on:
   push:
@@ -9,32 +9,47 @@ on:
 jobs:
   build:
     name: Build Code
-    runs-on: windows-latest
-    env: 
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    runs-on: linux-latest
     steps:
+    - name: Setup
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.301
-    - name: Setup Core project library
-      run: cd ./Core/Runtime && dotnet new classlib && dotnet add package Unity3D.UnityEngine --version 2018.3.5.1
-    - name: Setup Core Tests project
-      run: cd ./Core/Tests && dotnet new nunit && dotnet add package NSubstitute --version 4.2.2 && dotnet add package NUnit3TestAdapter --version 3.17.0
-    - name: Create solution
-      run: dotnet new sln && dotnet sln add ./Core/Runtime/Runtime.csproj ./Core/Tests/Tests.csproj && dotnet add ./Core/Tests/Tests.csproj reference ./Core/Runtime/Runtime.csproj
-    - name: Install dependencies
-      run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
-    - name: Cover Test
       run: |
-        choco install opencover.portable
-        OpenCover.Console.exe -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:test -filter:"+[Core*]* -[Tests*]*" -output:".\Core_coverage.xml" -oldstyle     
-    - uses: actions/upload-artifact@v2
+        dotnet new sln
+        cd ./Core/Runtime
+        dotnet new classlib
+        dotnet add package Unity3D.UnityEngine --version 2018.3.5.1
+        cd ../..
+        dotnet sln add ./Core/Runtime/Runtime.csproj
+        dotnet restore
+        dotnet build --configuration Release --no-restore
+    - name: Install Coverage Tools
+      id: cacheDotCover
+      uses: actions/cache@v2
       with:
-        name: Core-Coverage
-        path: Core_coverage.xml
+        path: |
+          dotCover
+        key: ${{ runner.os }}-DotCover
+    - if: steps.cacheDotCover.outputs.cache-hit != 'true'
+      run: |
+        mkdir dotCover
+        cd dotCover
+        curl https://download.jetbrains.com/resharper/ReSharperUltimate.2020.1.4/JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz -o ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz 
+        tar xvf ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
+    - name: Test
+      run: |
+        cd ./Core/Tests
+        dotnet new nunit
+        dotnet add package NSubstitute --version 4.2.2
+        dotnet add package NUnit3TestAdapter --version 3.17.0
+        cd ../..
+        dotnet sln add ./Core/Tests/Tests.csproj
+        dotnet add ./Core/Tests/Tests.csproj reference ./Core/Runtime/Runtime.csproj
+        dotnet restore
+        dotnet test -r ../../test_results/core/ --logger "trx"  
+        ./dotCover/dotCover.exe dotnet --output=Core_Coverage.xml --reportType=XML -- test
     - name: Upload Coverage Report
-      uses: codecov/codecov-action@v1.0.12
+      uses: codecov/codecov-action@v1.0.12 

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Cover Test
       run: |
         choco install opencover.portable
-        OpenCover.Console.exe -register:user -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:test -filter:"+[Core*]* -[Tests*]*" -output:".\Core_coverage.xml" -oldstyle     
+        OpenCover.Console.exe -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:test -filter:"+[Core*]* -[Tests*]*" -output:".\Core_coverage.xml" -oldstyle     
     - uses: actions/upload-artifact@v2
       with:
         name: Core-Coverage

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -32,5 +32,9 @@ jobs:
       run: |
         choco install opencover.portable
         OpenCover.Console.exe -register:user -target:"C:/Program Files/dotnet/dotnet.exe" -targetargs:test -filter:"+[Core*]* -[Tests*]*" -output:".\Core_coverage.xml" -oldstyle     
+    - uses: actions/upload-artifact@2
+      with:
+        name: Core-Coverage
+        path: Core_coverage.xml
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1.0.12

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -39,7 +39,9 @@ jobs:
       run: |
         mkdir dotCover
         cd dotCover
-        curl --silent --show-error --fail https://download.jetbrains.com/resharper/ReSharperUltimate.2020.1.4/JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz -o ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
+        curl https://download.jetbrains.com/resharper/ReSharperUltimate.2020.1.4/JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz -o ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
+    - run: |
+        cd dotCover
         tar xvf ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
     - name: Test
       run: |

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         mkdir dotCover
         cd dotCover
-        curl https://download.jetbrains.com/resharper/ReSharperUltimate.2020.1.4/JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz -o JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
+        wget https://download.jetbrains.com/resharper/ReSharperUltimate.2020.1.4/JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz -o JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
     - run: |
         cd dotCover
         tar xvf JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -40,6 +40,6 @@ jobs:
         dotnet build --configuration Debug --no-restore --output ./TestBuild
     - uses: dodopizza/dotcover-action@v1
       with:
-        dotCoverCommand: cover --ReportType=XML --TargetExecutable="./TestBuild/Tests.dll"
+        dotCoverCommand: cover --ReportType=XML --TargetExecutable="./TestBuild/Tests.dll" --Output="./Coverage/Core_coverage.xml"
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1.0.12 

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -39,8 +39,7 @@ jobs:
       run: |
         mkdir dotCover
         cd dotCover
-        curl https://download.jetbrains.com/resharper/ReSharperUltimate.2020.1.4/JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz -o ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz 
-        tar xvf ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
+        curl https://download.jetbrains.com/resharper/ReSharperUltimate.2020.1.4/JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz -o ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz && tar xvf ./JetBrains.dotCover.CommandLineTools.linux-x64.2020.1.4.tar.gz
     - name: Test
       run: |
         cd ./Core/Tests

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -40,5 +40,10 @@ jobs:
     - uses: dodopizza/dotcover-action@v1
       with:
         dotCoverCommand: dotnet --ReportType=XML --Output="./Coverage/Core_coverage.xml" -- test "./Core/Tests/Tests.csproj"
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: Core Coverage
+        path: ./Coverage/Core_coverage.xml
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1.0.12 

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -36,8 +36,10 @@ jobs:
         cd ../..
         dotnet sln add ./Core/Tests/Tests.csproj
         dotnet add ./Core/Tests/Tests.csproj reference ./Core/Runtime/Runtime.csproj
+        dotnet restore
+        dotnet build --configuration Debug --no-restore
     - uses: dodopizza/dotcover-action@v1
       with:
-        dotCoverCommand: cover --ReportType=XML
+        dotCoverCommand: cover --ReportType=XML --TargetExecutable="./Core/Tests/bin/Debug/netcoreapp2.1/Tests.dll"
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1.0.12 


### PR DESCRIPTION
For debugging the reason why codecov.io cannot parse the coverage xml.