### PR TITLE
Change code coverage tool from dotTrace to coverlet

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -43,6 +43,6 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: Core Coverage
-        path: ./Coverage
+        path: ./Core/Tests/Coverage/coverage.info
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1.0.12 

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -39,7 +39,7 @@ jobs:
         dotnet restore
     - uses: dodopizza/dotcover-action@v1
       with:
-        dotCoverCommand: dotnet --ReportType=XML --Output="./Coverage/Core_coverage.xml" -- test "./Core/Tests/Tests.csproj"
+        dotCoverCommand: dotnet --ReportType=NDependXML --Output="./Coverage/Core_coverage.xml" -- test "./Core/Tests/Tests.csproj"
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -36,14 +36,13 @@ jobs:
         cd ../..
         dotnet sln add ./Core/Tests/Tests.csproj
         dotnet add ./Core/Tests/Tests.csproj reference ./Core/Runtime/Runtime.csproj
+        dotnet add package coverlet.msbuild
         dotnet restore
-    - uses: dodopizza/dotcover-action@v1
-      with:
-        dotCoverCommand: dotnet --ReportType=NDependXML --Output="./Coverage/Core_coverage.xml" -- test "./Core/Tests/Tests.csproj"
+        dotnet test /p:CollectCoverage=true /p:CoverletOutput=Coverage/ /p:CoverletOutputFormat=lcov
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v2
       with:
         name: Core Coverage
-        path: ./Coverage/Core_coverage.xml
+        path: ./Coverage
     - name: Upload Coverage Report
       uses: codecov/codecov-action@v1.0.12 

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -33,10 +33,10 @@ jobs:
         dotnet new nunit
         dotnet add package NSubstitute --version 4.2.2
         dotnet add package NUnit3TestAdapter --version 3.17.0
+        dotnet add package coverlet.msbuild
         cd ../..
         dotnet sln add ./Core/Tests/Tests.csproj
         dotnet add ./Core/Tests/Tests.csproj reference ./Core/Runtime/Runtime.csproj
-        dotnet add package coverlet.msbuild
         dotnet restore
         dotnet test /p:CollectCoverage=true /p:CoverletOutput=Coverage/ /p:CoverletOutputFormat=lcov
     - name: Upload a Build Artifact

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Develop Branch Workflow](https://github.com/altunsercan/Kegstand/workflows/Develop%20Branch%20Workflow/badge.svg?branch=develop) [![Maintainability](https://api.codeclimate.com/v1/badges/7db3ee33d8eca1babb18/maintainability)](https://codeclimate.com/github/altunsercan/Kegstand/maintainability) [![codecov](https://codecov.io/gh/altunsercan/Kegstand/branch/develop/graph/badge.svg)](https://codecov.io/gh/altunsercan/Kegstand)
+
 # Kegstand 
 Discrete Event Simulator for Games
 
@@ -9,3 +11,4 @@ You remember the math problems about filling/emptying pools you likely solved in
 Discrete-Event Simulation is a method used to quickly simulate time depedent processes with interconnected entities. In industries they are used to model real life stuff like a factory floor and run simulations. But it is also useful for some management games where you can fast forward time but keep accurate simulation. Or have an online game where when you login, the game simulates what happened when you are away, like an incremental game.
 
 This library is created to provide a game library in Unity Package Manager (UPM) format to use Keg / Tap metaphor to build Discrete Event Simulators.
+ 


### PR DESCRIPTION
Changed code coverage tool from dotTrace to coverlet. Coverlet produces lcov format report which is supported by codecov.io.